### PR TITLE
HAWQ-1617. Incorrect processing of boolean operators in pushdown

### DIFF
--- a/src/backend/access/external/pxffilters.c
+++ b/src/backend/access/external/pxffilters.c
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
  * pxffilters.c
  *
  * Functions for handling push down of supported scan level filters to PXF.
- * 
+ *
  */
 #include "access/pxffilters.h"
 #include "catalog/pg_operator.h"
@@ -43,7 +43,7 @@ static bool supported_operator_type_scalar_array_op_expr(Oid type, PxfFilterDesc
 static void scalar_const_to_str(Const *constval, StringInfo buf);
 static void list_const_to_str(Const *constval, StringInfo buf);
 static List* append_attr_from_var(Var* var, List* attrs);
-static void enrich_trivial_expression(List *expressionItems);
+static void add_extra_and_expression_items(List *expressionItems, int extraAndOperatorsNum, BoolExpr **extraNodePointer);
 static List* get_attrs_from_expr(Expr *expr, bool* expressionIsSupported);
 
 /*
@@ -264,22 +264,21 @@ Oid pxf_supported_types[] =
 };
 
 static void
-pxf_free_expression_items_list(List *expressionItems, bool freeBoolExprNodes)
+pxf_free_expression_items_list(List *expressionItems)
 {
-	ExpressionItem 	*expressionItem = NULL;
-	int previousLength;
+	ExpressionItem *expressionItem = NULL;
 
 	while (list_length(expressionItems) > 0)
 	{
-		expressionItem = (ExpressionItem *) lfirst(list_head(expressionItems));
-		if (freeBoolExprNodes && nodeTag(expressionItem->node) == T_BoolExpr)
-		{
-			pfree((BoolExpr *)expressionItem->node);
-		}
+		expressionItem = (ExpressionItem *) linitial(expressionItems);
 		pfree(expressionItem);
 
-		/* to avoid freeing already freed items - delete all occurrences of current expression*/
-		previousLength = expressionItems->length + 1;
+		/*
+		 * to avoid freeing already freed items - delete all occurrences of
+		 * current expression
+		 */
+		int			previousLength = expressionItems->length + 1;
+
 		while (expressionItems != NULL && previousLength > expressionItems->length)
 		{
 			previousLength = expressionItems->length;
@@ -297,7 +296,6 @@ pxf_free_expression_items_list(List *expressionItems, bool freeBoolExprNodes)
  *
  * Basically this function just transforms expression tree to Reversed Polish Notation list.
  *
- *
  */
 static List *
 pxf_make_expression_items_list(List *quals, Node *parent, int *logicalOpsNum)
@@ -306,7 +304,7 @@ pxf_make_expression_items_list(List *quals, Node *parent, int *logicalOpsNum)
 	List			*result = NIL;
 	ListCell		*lc = NULL;
 	ListCell		*ilc = NULL;
-	
+
 	if (list_length(quals) == 0)
 		return NIL;
 
@@ -377,7 +375,7 @@ pxf_make_expression_items_list(List *quals, Node *parent, int *logicalOpsNum)
 				break;
 		}
 	}
-	
+
 	return result;
 }
 
@@ -872,7 +870,7 @@ append_attr_from_func_args(FuncExpr *expr, List* attrs, bool* expressionIsSuppor
 		} else if (IsA(node, Var)) {
 			attrs = append_attr_from_var((Var *) node, attrs);
 		} else if (IsA(node, OpExpr)) {
-			attrs = get_attrs_from_expr((OpExpr *) node, expressionIsSupported);
+			attrs = get_attrs_from_expr((Expr *) node, expressionIsSupported);
 		} else {
 			*expressionIsSupported = false;
 			return NIL;
@@ -1238,34 +1236,44 @@ list_const_to_str(Const *constval, StringInfo buf)
  * serializePxfFilterQuals
  *
  * Wrapper around pxf_make_filter_list -> pxf_serialize_filter_list.
- * Currently the only function exposed to the outside, however
- * we could expose the others in the future if needed.
  *
  * The function accepts the scan qual list and produces a serialized
  * string that represents the push down filters (See called functions
  * headers for more information).
  */
-char *serializePxfFilterQuals(List *quals)
+char *
+serializePxfFilterQuals(List *quals)
 {
 	char	*result = NULL;
 
 	if (pxf_enable_filter_pushdown)
 	{
 
-		int logicalOpsNum = 0;
-		List *expressionItems = pxf_make_expression_items_list(quals, NULL, &logicalOpsNum);
+		BoolExpr   *extraBoolExprNodePointer = NULL;
+		int			logicalOpsNum = 0;
+		List	   *expressionItems = pxf_make_expression_items_list(quals, NULL, &logicalOpsNum);
 
-		//Trivial expression means list of OpExpr implicitly ANDed
-		bool isTrivialExpression = logicalOpsNum == 0 && expressionItems && expressionItems->length > 1;
-
-		if (isTrivialExpression)
+		/*
+		* The 'expressionItems' are always explicitly AND'ed. If there are extra
+		* logical operations present, they are the items in the same list. We
+		* need to add AND items only for "meaningful" expression items (not
+		* including these logical operations)
+		*/
+		if (expressionItems)
 		{
-			enrich_trivial_expression(expressionItems);
-		}
-		result  = pxf_serialize_filter_list(expressionItems);
-		pxf_free_expression_items_list(expressionItems, isTrivialExpression);
-	}
+			int			extraAndOperatorsNum = expressionItems->length - 1 - logicalOpsNum;
 
+			add_extra_and_expression_items(expressionItems, extraAndOperatorsNum, &extraBoolExprNodePointer);
+		}
+
+		result = pxf_serialize_filter_list(expressionItems);
+
+		if (extraBoolExprNodePointer)
+		{
+			pfree(extraBoolExprNodePointer);
+		}
+		pxf_free_expression_items_list(expressionItems);
+	}
 
 	elog(DEBUG1, "serializePxfFilterQuals: filter result: %s", (result == NULL) ? "null" : result);
 
@@ -1273,29 +1281,32 @@ char *serializePxfFilterQuals(List *quals)
 }
 
 /*
- * Takes list of expression items which supposed to be just a list of OpExpr
- * and adds needed number of AND items
- *
+ * Adds a given number of AND expression items to an existing list of expression items
+ * Note that this will not work if OR operators are introduced
  */
-void enrich_trivial_expression(List *expressionItems) {
-
-
-	int logicalOpsNumNeeded = expressionItems->length - 1;
-
-	if (logicalOpsNumNeeded > 0)
+void
+add_extra_and_expression_items(List *expressionItems, int extraAndOperatorsNum, BoolExpr **extraNodePointer)
+{
+	if ((!expressionItems) || (extraAndOperatorsNum < 1))
 	{
-		ExpressionItem *andExpressionItem = (ExpressionItem *) palloc0(sizeof(ExpressionItem));
-		BoolExpr *andExpr = makeNode(BoolExpr);
+		*extraNodePointer = NULL;
+		return;
+	}
 
-		andExpr->boolop = AND_EXPR;
+	ExpressionItem *andExpressionItem = (ExpressionItem *) palloc0(sizeof(ExpressionItem));
 
-		andExpressionItem->node = (Node *) andExpr;
-		andExpressionItem->parent = NULL;
-		andExpressionItem->processed = false;
+	BoolExpr   *andExpr = makeNode(BoolExpr);
 
-		for (int i = 0; i < logicalOpsNumNeeded; i++) {
-			expressionItems = lappend(expressionItems, andExpressionItem);
-		}
+	andExpr->boolop = AND_EXPR;
+	*extraNodePointer = andExpr;
+
+	andExpressionItem->node = (Node *) andExpr;
+	andExpressionItem->parent = NULL;
+	andExpressionItem->processed = false;
+
+	for (int i = 0; i < extraAndOperatorsNum; i++)
+	{
+		expressionItems = lappend(expressionItems, andExpressionItem);
 	}
 }
 

--- a/src/backend/access/external/test/pxffilters_test.c
+++ b/src/backend/access/external/test/pxffilters_test.c
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -814,7 +814,7 @@ void test__pxf_serialize_filter_list__oneFilter(void **state)
 	char* result = pxf_serialize_filter_list(expressionItems);
 	assert_string_equal(result, "a0c25s4d1984o5");
 
-	pxf_free_expression_items_list(expressionItems, true);
+	pxf_free_expression_items_list(expressionItems);
 	expressionItems = NIL;
 	pfree(result);
 
@@ -832,7 +832,7 @@ void test__pxf_serialize_fillter_list__nullFilter(void **state)
 	char* result = pxf_serialize_filter_list(expressionItems);
 	assert_string_equal(result, "a0o8");
 
-	pxf_free_expression_items_list(expressionItems, true);
+	pxf_free_expression_items_list(expressionItems);
 	expressionItems = NIL;
 	pfree(result);
 
@@ -870,7 +870,7 @@ test__pxf_serialize_filter_list__manyFilters(void **state)
 
 	assert_int_equal(expressionItems->length, 2*trivialExpressionItems - 1);
 
-	pxf_free_expression_items_list(expressionItems, true);
+	pxf_free_expression_items_list(expressionItems);
 	expressionItems = NIL;
 }
 
@@ -931,8 +931,8 @@ test__extractPxfAttributes_supported_function_one_arg(void **state) {
 	}
 }
 
-int 
-main(int argc, char* argv[]) 
+int
+main(int argc, char* argv[])
 {
 	cmockery_parse_arguments(argc, argv);
 


### PR DESCRIPTION
When accessing external tables, the pushdown feature sometimes works incorrect. Consider the following query:
```
SELECT * FROM table_ex WHERE bool1=false AND id1=60003;
```
When this query is executed, an error "stack is not empty ..." happens.

Turns out that such query is transformed into a list of three items that represents the constraints: `BoolExpr`, `Var` and `OpExpr` (this is equal to a query `WHERE NOT(bool1 = true) AND (id1 = 60003)`). Note that the list does not contain (implicit) AND operators.

Then, the list is processed by a [piece of code in pxffilters.c](https://github.com/apache/incubator-hawq/blob/master/src/backend/access/external/pxffilters.c#L1259), where there is a check of presence of `BoolExpr`. If expression items of this kind are detected, no implicit AND operators are added.

In the case described, one 'BoolExpr' element is present, and no implicit AND operators are added. This leads to the error mentioned above.

This commit changes the signatures of `enrich_trivial_expression()` and `pxf_free_expression_items_list()` from [pxffilters.c](https://github.com/apache/incubator-hawq/blob/master/src/backend/access/external/pxffilters.c) in order to fix the bug:
* A number of impicit AND operators to be added is now passed to `add_extra_and_expression_items()`
* `add_extra_and_expression_items()` now requires the pointer to pointer to `Node` object to store the pointer to an expression item for the implicit AND that it creates (before, it was stored in the expression item itself; however, due to the presence of other logical operators, we cannot rely on this mechanism)
* `pxf_free_expression_items_list()` simplifies, due to the changes in the way how the pointer to `Node` object is stored

The current mechanism of implicit AND expressions addition works well only while the
OR operators are not supported (or not present in a query). When the OR operators appear, the implicit ANDs must be added in different parts of a query, not only to the end, as done now.