### PR TITLE
Relogin from keytab when security is enabled instead of using the TOKEN

### DIFF
--- a/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/ParquetResolver.java
+++ b/pxf/pxf-hdfs/src/main/java/org/apache/hawq/pxf/plugins/hdfs/ParquetResolver.java
@@ -57,7 +57,7 @@ public class ParquetResolver extends Plugin implements ReadResolver {
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      * @param schema the MessageType instance, which is obtained from the Parquet file footer
      */
     public List<OneField> getFields(OneRow row, MessageType schema) throws Exception

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/BridgeResource.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/BridgeResource.java
@@ -97,7 +97,6 @@ public class BridgeResource extends RestResource {
         }
 
         ProtocolData protData = new ProtocolData(params);
-        SecuredHDFS.verifyToken(protData, servletContext);
         Bridge bridge;
         float sampleRatio = protData.getStatsSampleRatio();
         if (sampleRatio > 0) {

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/FragmenterResource.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/FragmenterResource.java
@@ -147,7 +147,6 @@ public class FragmenterResource extends RestResource {
         if (protData.getFragmenter() == null) {
             protData.protocolViolation("fragmenter");
         }
-        SecuredHDFS.verifyToken(protData, servletContext);
 
         return protData;
     }

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/MetadataResource.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/MetadataResource.java
@@ -103,7 +103,6 @@ public class MetadataResource extends RestResource {
             ProtocolData protData = new ProtocolData(params, profile.toLowerCase());
 
             // 0. Verify token
-            SecuredHDFS.verifyToken(protData, servletContext);
 
             // 1. start MetadataFetcher
             MetadataFetcher metadataFetcher = MetadataFetcherFactory.create(protData);

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/WritableResource.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/rest/WritableResource.java
@@ -118,7 +118,6 @@ public class WritableResource extends RestResource{
         ProtocolData protData = new ProtocolData(params);
         protData.setDataSource(path);
 
-        SecuredHDFS.verifyToken(protData, servletContext);
         Bridge bridge = new WriteBridge(protData);
 
         // THREAD-SAFE parameter has precedence

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/servlet/SecurityServletFilter.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/servlet/SecurityServletFilter.java
@@ -88,6 +88,10 @@ public class SecurityServletFilter implements Filter {
                 }
             };
 
+            if (UserGroupInformation.isSecurityEnabled()) {
+                UserGroupInformation.getLoginUser().reloginFromKeytab();
+            }
+
             // create proxy user UGI from the UGI of the logged in user and execute the servlet chain as that user
             UserGroupInformation proxyUGI = null;
             try {

--- a/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/utilities/ProtocolData.java
+++ b/pxf/pxf-service/src/main/java/org/apache/hawq/pxf/service/utilities/ProtocolData.java
@@ -8,9 +8,9 @@ package org.apache.hawq.pxf.service.utilities;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -367,11 +367,6 @@ public class ProtocolData extends InputData {
             this.user = getProperty("USER");
         } else {
             this.user = getOptionalProperty("USER");
-        }
-
-        /* Kerberos token information */
-        if (UserGroupInformation.isSecurityEnabled()) {
-            this.token = getProperty("TOKEN");
         }
     }
 

--- a/pxf/pxf-service/src/test/java/org/apache/hawq/pxf/service/utilities/ProtocolDataTest.java
+++ b/pxf/pxf-service/src/test/java/org/apache/hawq/pxf/service/utilities/ProtocolDataTest.java
@@ -8,9 +8,9 @@ package org.apache.hawq.pxf.service.utilities;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -196,19 +196,6 @@ public class ProtocolDataTest {
             assertEquals(e.getMessage(),
                     "Fragment metadata information must be Base64 encoded."
                             + "(Bad value: " + badValue + ")");
-        }
-    }
-
-    @Test
-    public void nullTokenThrows() throws Exception {
-        when(UserGroupInformation.isSecurityEnabled()).thenReturn(true);
-
-        try {
-            new ProtocolData(parameters);
-            fail("null X-GP-TOKEN should throw exception");
-        } catch (IllegalArgumentException e) {
-            assertEquals(e.getMessage(),
-                    "Internal server error. Property \"TOKEN\" has no value in current request");
         }
     }
 


### PR DESCRIPTION
- We are now supporting Kerberos login with GPDB, which unlike HAWQ does
  not pass the TOKEN parameter. Thus, we re-login from the local keytab
  to authenticate the user.

Co-authored-by: Lav Jain <ljain@pivotal.io>
Co-authored-by: Ben Christel <bchristel@pivotal.io>
Co-authored-by: Shivram Mani <smani@pivotal.io>