### PR TITLE
HAWQ-1687. Fix travis broken due to missing apr-1-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
       python
       snappy
       apr
+      apr-util
   - brew reinstall
       protobuf
       protobuf-c


### PR DESCRIPTION
Create for hour, 

need to add apr-util libarary in hawq travis