### PR TITLE
JIRA-1753. add datalocality comments

### DIFF
--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -4583,14 +4583,15 @@ calculate_planner_segment_num(PlannedStmt *plannedstmt, Query *query,
 				if ((context.resultRelationHashSegNum < context.externTableForceSegNum
 						&& context.externTableForceSegNum != 0)
 						|| (context.resultRelationHashSegNum < context.externTableLocationSegNum)) {
-					elog(ERROR, "Could not allocate enough memory! "
-							"bucket number of result hash table and external table should match each other");
+					/* bucket number of result table must be equal to or larger than
+					 * location number of external table.*/
+					elog(ERROR, "bucket number of result hash table and external table should match each other");
 				}
 				maxTargetSegmentNumber = context.resultRelationHashSegNum;
 				minTargetSegmentNumber = context.resultRelationHashSegNum;
 			}
 			else if(context.externTableForceSegNum > 0){
-				/* bucket number of external table must be the same with the number of virtual segments*/
+				/* location number of external table must be less than the number of virtual segments*/
 				if(context.externTableForceSegNum < context.externTableLocationSegNum){
 					elog(ERROR, "external table bucket number should match each other");
 				}


### PR DESCRIPTION
location number of external table should less than bucketnum of target table

description:

when load data from external table like 
insert into table from exttable.
bucket number of internal table must be less than location number. but the error message is "can not allocate memory."
This is confused to user, so change it.

issue in jira
https://issues.apache.org/jira/projects/HAWQ/issues/HAWQ-1753?filter=allopenissues