### PR TITLE
HAWQ-1754. add comment for max segment number count for random table.

### DIFF
--- a/src/backend/cdb/cdbdatalocality.c
+++ b/src/backend/cdb/cdbdatalocality.c
@@ -4633,6 +4633,10 @@ calculate_planner_segment_num(PlannedStmt *plannedstmt, Query *query,
 			} else {
 				maxTargetSegmentNumber = context.randomSegNum;
 				if(context.externTableLocationSegNum > 0 && maxTargetSegmentNumber < GetQueryVsegNum()){
+					/*
+					 * adjust max segment number for random table by rm_nvseg_perquery_perseg_limit
+					 * and rm_nvseg_perquery_limit.
+					 */
 					maxTargetSegmentNumber = GetQueryVsegNum();
 				}
 				minTargetSegmentNumber = context.minimum_segment_num;


### PR DESCRIPTION
max segment number for random table is adjusted by limit of virtual segment number per segment. add comment for it.