### PR TITLE
HAWQ-1769. Fix DirectoryIterator of libhdfs

### DIFF
--- a/depends/libhdfs3/src/client/DirectoryIterator.h
+++ b/depends/libhdfs3/src/client/DirectoryIterator.h
@@ -45,6 +45,7 @@ private:
 
 private:
     bool needLocations;
+    bool hasMore;
     Hdfs::Internal::FileSystemImpl * filesystem;
     size_t next;
     std::string path;

--- a/depends/libhdfs3/src/server/Namenode.h
+++ b/depends/libhdfs3/src/server/Namenode.h
@@ -514,6 +514,8 @@ public:
      * @param a partial listing starting after startAfter
      * @param dl append the returned directories.
      *
+     * @return true if there are more remaining entries.
+     *
      * @throw AccessControlException permission denied
      * @throw FileNotFoundException file <code>src</code> is not found
      * @throw UnresolvedLinkException If <code>src</code> contains a symlink


### PR DESCRIPTION
The DirectoryIterator of libhdfs has some problems now:
* even if the `getListing` RPC returns "remainingentries = 0", the following invoking of DirectoryIterator::hasNext() may still trigger an unnecessary `getListing` RPC to the server.
* moreover, in the above case, if the server returns a non-empty list (so it is a server bug because the server should return an empty list) when the client send an unnecessary `getListing` RPC, then DirectoryIterator::hasNext() will return true, and we will enter endless loop.