### PR TITLE
HAWQ-1779. Add GitHub Action for building on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Apache HAWQ
+
+on: [push]
+
+jobs:
+  build-on-macOS:
+
+    runs-on: macOS-10.15
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: lint check
+      run: |
+        csrutil status
+        ulimit -a
+        mvn apache-rat:check
+
+    - name: install thirdparty
+      run: |
+        # download prebuilt libraries
+        curl -sL http://yum.oushu-tech.com/oushurepo/yumrepo/internal/linux/toolchain/dependency-Darwin.tar.xz | tar -xJ -C $GITHUB_WORKSPACE
+        for file in $(find $GITHUB_WORKSPACE/dependency-Darwin/package/bin -name '*' -type f) $(find $GITHUB_WORKSPACE/dependency-Darwin/package/lib -name '*.dylib' -type f); do
+          if [[ $(file $file | grep Mach-O) ]]; then
+            install_name_tool -add_rpath $GITHUB_WORKSPACE/dependency-Darwin/package/lib $file;
+          fi
+        done
+        install_name_tool -add_rpath $GITHUB_WORKSPACE/dependency-Darwin/package/lib/perl5/5.28.0/darwin-thread-multi-2level/CORE/ $GITHUB_WORKSPACE/dependency-Darwin/package/bin/perl
+
+    - name: configure
+      run: |
+        source $GITHUB_WORKSPACE/dependency-Darwin/package/env.sh
+        export CFLAGS="$CFLAGS -w"
+        export LDFLAGS="$LDFLAGS -Wl,-rpath,$GITHUB_WORKSPACE/dependency-Darwin/package/lib"
+
+        ./configure --enable-debug --prefix=/tmp/hawq || cat config.log
+        test -f config.status
+
+    - name: build hawq
+      run: |
+        source $GITHUB_WORKSPACE/dependency-Darwin/package/env.sh
+        make -j$(nproc)
+        make -j$(nproc) install
+
+    - name: build feature-test
+      run: |
+        source $GITHUB_WORKSPACE/dependency-Darwin/package/env.sh
+        make -j$(nproc) feature-test
+
+    - name: test executable
+      run: |
+        source /tmp/hawq/greenplum_path.sh
+        postgres -V
+        src/test/feature/feature-test --gtest_list_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,5 +92,7 @@ script:
   - make feature-test-clean
 
 branches:
+  only:
+    - travis
   except:
     - legacy

--- a/depends/storage/src/CMakeLists.txt
+++ b/depends/storage/src/CMakeLists.txt
@@ -15,7 +15,6 @@ set(CMAKE_MACOSX_RPATH 1)
 SET(storage_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 SET(storage_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/storage)
 SET(orcformat_proto_DIR ${storage_SRC_DIR}/format/orc)
-SET(Protobuf_PROTOC_EXECUTABLE /usr/local/bin/protoc)
 
 file(GLOB proto_files "${storage_SRC_DIR}/format/orc/*.proto")
 set(proto_SRC_DIR ${CMAKE_BINARY_DIR}/src/storage/format/orc)

--- a/depends/univplan/src/CMakeLists.txt
+++ b/depends/univplan/src/CMakeLists.txt
@@ -12,7 +12,6 @@ set(CMAKE_MACOSX_RPATH 1)
 SET(univplan_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 SET(univplan_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/univplan)
 SET(univplan_proto_DIR ${univplan_SRC_DIR}/proto)
-SET(Protobuf_PROTOC_EXECUTABLE /usr/local/bin/protoc)
 
 file(GLOB proto_files "${univplan_SRC_DIR}/proto/*.proto")
 set(proto_SRC_DIR ${CMAKE_BINARY_DIR}/src/univplan/proto)

--- a/src/bin/gpfdist/Makefile
+++ b/src/bin/gpfdist/Makefile
@@ -43,13 +43,6 @@ INCLUDES := $$($(APR_CFG) --includes) -I$(code_dir) -I$(CURDIR)/../../../src/inc
 CFLAGS   := $$($(APR_CFG) --cflags) -Wall $(GPFXDIST) $(CFLAGS)
 LIBS     := $$($(APR_CFG) --link-ld --libs) $(LIBS)
 
-# workaround for 'brew link openssl --force' error on MacOS 10.12
-UNAME = $(shell uname)
-ifeq (Darwin, $(UNAME))
-	INCLUDES := $(INCLUDES) -I/usr/local/opt/openssl/include
-	LIBS := $(LIBS) -L/usr/local/opt/openssl/lib
-endif
-
 sol10_sparc_32_CPPFLAGS = -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
 sol9_sparc_32_CPPFLAGS  = -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
 sol8_sparc_32_CPPFLAGS  = -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64


### PR DESCRIPTION
Since building HAWQ on macOS(and also other platform) relies on several
dependency libraries, which are hard to track version via Homebrew, a
prebuilt dependency leave developers free from the tedious work.

Such process is easy to maintain and verify via GitHub Action. The
workable workflow file also indicates the new users on how to build
Apache HAWQ on macOS quickly.

This commit disables the previous problematic Travis CI as well.