### PR TITLE
HAWQ-1782. Fix failed to read EXTERNAL TABLE of GPFDIST protocol

### DIFF
--- a/.github/workflows/scripts/gtest_filter_negative
+++ b/.github/workflows/scripts/gtest_filter_negative
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 export GTEST_FILTER_NEGATIVE=\
-TestErrorTable.TestErrorTableAll:\
 TestCommonLib.TestHdfsConfig:\
 TestExtOrc.TestNormalPath:\
 TestExtOrc.BoolTypeTest:\

--- a/src/backend/access/external/url.c
+++ b/src/backend/access/external/url.c
@@ -361,13 +361,13 @@ fill_buffer(URL_FILE *file, int want)
 						e, curl_easy_strerror(e));
 		}
 
-		if (maxfd <= 0)
+		if (maxfd == -1)
 		{
-			curl->still_running = 0;
-			break;
+			/* fall through to curl_multi_perform directly */
+			pg_usleep(100);
+			nfds = 1;
 		}
-
-        if (-1 == (nfds = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout)))
+		else if (-1 == (nfds = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout)))
 		{
 			if (errno == EINTR || errno == EAGAIN)
 				continue;

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -4707,7 +4707,7 @@ CreateExternalStmt:	CREATE OptWritable EXTERNAL OptWeb OptTemp TABLE qualified_n
 
 OptWritable:	WRITABLE				{ $$ = TRUE; }
 				| READABLE				{ $$ = FALSE; }
-				| /*EMPTY*/				{ $$ = TRUE; }
+				| /*EMPTY*/				{ $$ = FALSE; }
 				;
 
 OptWeb:		WEB						{ $$ = TRUE; }


### PR DESCRIPTION
- revise CREATE EXTERNAL TABLE default to READABLE EXTERNAL TABLE

- fix read from EXTERNAL TABLE of GPFDIST protocol

The documented behaviour of CREATE EXTERNAL TABLE indicates a READABLE
TABLE but used to be violated.

Referring to https://curl.se/libcurl/c/curl_multi_fdset.html,
```
If no file descriptors are set by libcurl, max_fd will contain -1 when
this function returns. Otherwise it will contain the highest descriptor
number libcurl set. When libcurl returns -1 in max_fd, it is because
libcurl currently does something that isn't possible for your
application to monitor with a socket and unfortunately you can then not
know exactly when the current action is completed using select(). You
then need to wait a while before you proceed and call curl_multi_perform
anyway. How long to wait? Unless curl_multi_timeout gives you a lower
number, we suggest 100 milliseconds or so, but you may want to test it
out in your own particular conditions to find a suitable value.
```
it is not an error of `max_fd == -1`. Moreover, the situation of
`max_fd == -1` seems common on macOS.