### PR TITLE
HAWQ-1788: set default value for dfs.domain.socket.path

### DIFF
--- a/depends/libhdfs3/src/common/SessionConfig.cpp
+++ b/depends/libhdfs3/src/common/SessionConfig.cpp
@@ -148,7 +148,7 @@ SessionConfig::SessionConfig(const Config & conf) {
         {&rpcAuthMethod, "hadoop.security.authentication", "simple" },
         {&kerberosCachePath, "hadoop.security.kerberos.ticket.cache.path", "" },
         {&logSeverity, "dfs.client.log.severity", "INFO" },
-        {&domainSocketPath, "dfs.domain.socket.path", ""},
+        {&domainSocketPath, "dfs.domain.socket.path", "/var/lib/hadoop-hdfs/dn_socket"},
         {&kmsUrl, "dfs.encryption.key.provider.uri", "" },
         {&kmsAuthMethod, "hadoop.kms.authentication.type", "simple" }
     };


### PR DESCRIPTION
Instead of setting empty string, an example value from HDFS doc should
be better to follow.

https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/ShortCircuitLocalReads.html

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>